### PR TITLE
Add auto-resize functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 secrets.json
 __pycache__/
 .cache/
+bin/
+include/
+lib/
+local/
 ext-posts-dependencies/
 ext-services.zip
+resize-dependencies/
+resize.zip

--- a/ResizeImage.py
+++ b/ResizeImage.py
@@ -19,7 +19,7 @@ def handler(event, _):
         # https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
         key = unquote_plus(record['s3']['object']['key'])
         log.debug("Got new file: %s:%s", bucket, key)
-        original = get_file(original, bucket, key)
+        original = get_file(bucket, key)
         resized = resize_image(original)
         put_file(resized,
                  os.environ.get('DEST_BUCKET', 'calligre-images'),
@@ -39,7 +39,7 @@ def get_file(bucket, key):
 
 
 def resize_image(src):
-    # thumbnail is badly named, it'll resize the image while keping the aspect ratio
+    # thumbnail is badly named, it resizes the image, keeping the aspect ratio
     # We use 1024 px on the longest edge as a good balance
     size = (1024, 1024)
     _, outfile = mkstemp()

--- a/ResizeImage.py
+++ b/ResizeImage.py
@@ -1,0 +1,62 @@
+import logging
+import os
+from tempfile import mkstemp
+
+from PIL import Image
+import boto3
+
+s3 = boto3.client('s3')  # pylint: disable=C0103
+
+log = logging.getLogger(__name__)  # pylint: disable=C0103
+log.setLevel(logging.DEBUG)
+
+
+def handler(event, _):
+    for record in event['Records']:
+        _, original = mkstemp()
+        name = record['s3']['object']['key']
+        bucket = record['s3']['bucket']['name']
+        get_file(original, bucket, name)
+        resized = resize_image(original)
+        put_file(resized,
+                 os.environ.get('DEST_BUCKET', 'calligre-images'),
+                 name)
+        delete_file(bucket, name)
+
+
+def get_file(dest, bucket, key):
+    try:
+        s3.download_file(bucket, key, dest)
+    except Exception as ex:
+        log.exception(ex)
+        raise ex
+
+
+def resize_image(src):
+    size = (1024, 1024)
+    _, outfile = mkstemp()
+    try:
+        image = Image.open(src)
+        image.thumbnail(size)
+        image.save(outfile, "JPEG")
+        return outfile
+    except IOError as ex:
+        log.exception("Cannot resize image")
+        raise ex
+
+
+def put_file(src, bucket, key):
+    log.info("Putting %s into %s:%s", src, bucket, key)
+    try:
+        s3.upload_file(src, bucket, key)
+    except Exception as ex:
+        log.exception(ex)
+        raise ex
+
+
+def delete_file(bucket, key):
+    try:
+        s3.delete_object(Bucket=bucket, Key=key)
+    except Exception as ex:
+        log.exception(ex)
+        raise ex

--- a/ResizeImage.py
+++ b/ResizeImage.py
@@ -11,6 +11,8 @@ s3 = boto3.client('s3')  # pylint: disable=C0103
 log = logging.getLogger(__name__)  # pylint: disable=C0103
 log.setLevel(logging.DEBUG)
 
+DEST_BUCKET = os.environ.get('DEST_BUCKET', 'calligre-images')
+
 
 def handler(event, _):
     for record in event['Records']:
@@ -22,9 +24,7 @@ def handler(event, _):
         log.debug("Got new file: %s:%s, size %d", bucket, key, size)
         original = get_file(bucket, key)
         resized = resize_image(original)
-        put_file(resized,
-                 os.environ.get('DEST_BUCKET', 'calligre-images'),
-                 key)
+        put_file(resized, DEST_BUCKET, key)
         delete_file(bucket, key)
 
 

--- a/ResizeImage.py
+++ b/ResizeImage.py
@@ -46,7 +46,7 @@ def resize_image(src):
     _, outfile = mkstemp()
     try:
         image = Image.open(src)
-        log.debug("Resizing: %s, original size: %dx%d", src, image.size())
+        log.debug("Resizing: %s, original size: %s", src, image.size())
         image.thumbnail(size)
         image.save(outfile, "JPEG")
         return outfile

--- a/ResizeImage.py
+++ b/ResizeImage.py
@@ -18,7 +18,8 @@ def handler(event, _):
         # S3 keys are urlencoded in event notifications
         # https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
         key = unquote_plus(record['s3']['object']['key'])
-        log.debug("Got new file: %s:%s", bucket, key)
+        size = record['s3']['object']['size']
+        log.debug("Got new file: %s:%s, size %d", bucket, key, size)
         original = get_file(bucket, key)
         resized = resize_image(original)
         put_file(resized,
@@ -43,9 +44,9 @@ def resize_image(src):
     # We use 1024 px on the longest edge as a good balance
     size = (1024, 1024)
     _, outfile = mkstemp()
-    log.debug("Resizing: %s", src)
     try:
         image = Image.open(src)
+        log.debug("Resizing: %s, original size: %dx%d", src, image.size())
         image.thumbnail(size)
         image.save(outfile, "JPEG")
         return outfile

--- a/ResizeImage.py
+++ b/ResizeImage.py
@@ -14,13 +14,12 @@ log.setLevel(logging.DEBUG)
 
 def handler(event, _):
     for record in event['Records']:
-        _, original = mkstemp()
         bucket = record['s3']['bucket']['name']
         # S3 keys are urlencoded in event notifications
         # https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
         key = unquote_plus(record['s3']['object']['key'])
         log.debug("Got new file: %s:%s", bucket, key)
-        get_file(original, bucket, key)
+        original = get_file(original, bucket, key)
         resized = resize_image(original)
         put_file(resized,
                  os.environ.get('DEST_BUCKET', 'calligre-images'),
@@ -28,20 +27,24 @@ def handler(event, _):
         delete_file(bucket, key)
 
 
-def get_file(dest, bucket, key):
+def get_file(bucket, key):
+    log.debug("Fetching file: %s:%s", bucket, key)
     try:
-        log.debug("Fetching file: %s:%s", bucket, key)
+        _, dest = mkstemp()
         s3.download_file(bucket, key, dest)
+        return dest
     except Exception as ex:
         log.exception(ex)
         raise ex
 
 
 def resize_image(src):
+    # thumbnail is badly named, it'll resize the image while keping the aspect ratio
+    # We use 1024 px on the longest edge as a good balance
     size = (1024, 1024)
     _, outfile = mkstemp()
+    log.debug("Resizing: %s", src)
     try:
-        log.debug("Resizing: %s", src)
         image = Image.open(src)
         image.thumbnail(size)
         image.save(outfile, "JPEG")
@@ -61,8 +64,8 @@ def put_file(src, bucket, key):
 
 
 def delete_file(bucket, key):
+    log.debug("Deleting: %s:%s", bucket, key)
     try:
-        log.debug("Deleting: %s:%s", bucket, key)
         s3.delete_object(Bucket=bucket, Key=key)
     except Exception as ex:
         log.exception(ex)

--- a/ResizeImage.py
+++ b/ResizeImage.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from tempfile import mkstemp
+from urllib import unquote_plus
 
 from PIL import Image
 import boto3
@@ -14,18 +15,22 @@ log.setLevel(logging.DEBUG)
 def handler(event, _):
     for record in event['Records']:
         _, original = mkstemp()
-        name = record['s3']['object']['key']
         bucket = record['s3']['bucket']['name']
-        get_file(original, bucket, name)
+        # S3 keys are urlencoded in event notifications
+        # https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html
+        key = unquote_plus(record['s3']['object']['key'])
+        log.debug("Got new file: %s:%s", bucket, key)
+        get_file(original, bucket, key)
         resized = resize_image(original)
         put_file(resized,
                  os.environ.get('DEST_BUCKET', 'calligre-images'),
-                 name)
-        delete_file(bucket, name)
+                 key)
+        delete_file(bucket, key)
 
 
 def get_file(dest, bucket, key):
     try:
+        log.debug("Fetching file: %s:%s", bucket, key)
         s3.download_file(bucket, key, dest)
     except Exception as ex:
         log.exception(ex)
@@ -36,6 +41,7 @@ def resize_image(src):
     size = (1024, 1024)
     _, outfile = mkstemp()
     try:
+        log.debug("Resizing: %s", src)
         image = Image.open(src)
         image.thumbnail(size)
         image.save(outfile, "JPEG")
@@ -46,7 +52,7 @@ def resize_image(src):
 
 
 def put_file(src, bucket, key):
-    log.info("Putting %s into %s:%s", src, bucket, key)
+    log.debug("Putting %s into %s:%s", src, bucket, key)
     try:
         s3.upload_file(src, bucket, key)
     except Exception as ex:
@@ -56,6 +62,7 @@ def put_file(src, bucket, key):
 
 def delete_file(bucket, key):
     try:
+        log.debug("Deleting: %s:%s", bucket, key)
         s3.delete_object(Bucket=bucket, Key=key)
     except Exception as ex:
         log.exception(ex)

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 2.7.11
+    version: 2.7.12
 
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   python:
-    version: 3.5.0
+    version: 2.7.11
 
 dependencies:
   override:

--- a/deploy-image-resize.sh
+++ b/deploy-image-resize.sh
@@ -9,14 +9,13 @@ pep8 ${HANDLER}
 pyflakes ${HANDLER}
 mkdir -p ${DEP_FOLDER}
 cd ${DEP_FOLDER}
-if [ ! -d "Pillow-3.1.1-py2.7.egg-info" ]; then
-    wget https://raw.githubusercontent.com/Miserlou/lambda-packages/cc02ac84589e92e28c55f811292cdaeae7a87e5d/lambda_packages/Pillow/Pillow-3.1.1.tar.gz
-    tar -xzf Pillow-3.1.1.tar.gz
-    rm Pillow-3.1.1.tar.gz
-    find . -name '*.py' -delete
+if [ ! -d "Pillow-3.4.2.dist-info" ]; then
+    wget https://pypi.python.org/packages/c0/47/6900d13aa6112610df4c9b34d57f50a96b35308796a3a27458d0c9ac87f7/Pillow-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
+    unzip Pillow-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
+    rm Pillow-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
 fi
 
-zip -r ../${DEST_FILE} PIL lib*
+zip -r ../${DEST_FILE} PIL
 cd ..
 zip -r ${DEST_FILE} ${HANDLER}
 aws s3 cp ${DEST_FILE} "s3://calligre/${DEST_FILE}"

--- a/deploy-image-resize.sh
+++ b/deploy-image-resize.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+export DEP_FOLDER="resize-dependencies"
+export DEST_FILE="resize.zip"
+export HANDLER="ResizeImage.py"
+rm -f ${DEST_FILE}
+pep8 ${HANDLER}
+pyflakes ${HANDLER}
+mkdir -p ${DEP_FOLDER}
+cd ${DEP_FOLDER}
+if [ ! -d "Pillow-3.1.1-py2.7.egg-info" ]; then
+    wget https://raw.githubusercontent.com/Miserlou/lambda-packages/cc02ac84589e92e28c55f811292cdaeae7a87e5d/lambda_packages/Pillow/Pillow-3.1.1.tar.gz
+    tar -xzf Pillow-3.1.1.tar.gz
+    rm Pillow-3.1.1.tar.gz
+    find . -name '*.py' -delete
+fi
+
+zip -r ../${DEST_FILE} PIL lib*
+cd ..
+zip -r ${DEST_FILE} ${HANDLER}
+aws s3 cp ${DEST_FILE} "s3://calligre/${DEST_FILE}"
+aws lambda update-function-code --function-name calligre-resize-images --s3-bucket calligre --s3-key "${DEST_FILE}" --publish --region us-west-2

--- a/deploy-image-resize.sh
+++ b/deploy-image-resize.sh
@@ -10,6 +10,7 @@ pyflakes ${HANDLER}
 mkdir -p ${DEP_FOLDER}
 cd ${DEP_FOLDER}
 if [ ! -d "Pillow-3.4.2.dist-info" ]; then
+    # Updates: Use the latest cp27mu-manylinux1 wheel from https://pypi.python.org/pypi/Pillow/
     wget https://pypi.python.org/packages/c0/47/6900d13aa6112610df4c9b34d57f50a96b35308796a3a27458d0c9ac87f7/Pillow-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
     unzip Pillow-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
     rm Pillow-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl


### PR DESCRIPTION
Images now get resized when uploaded to a bucket!

~600ms for the actual resizing with a 768MB container, ~2 sec for the complete activation, download/resize/upload/delete cycle.

Might have to look at the cross posting function, add a bit of delay to make sure the resized file will be available.