### PR TITLE
Add the region parameter, because sync dies without it 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,9 +16,9 @@ deployment:
   production:
     branch: master
     commands:
-      - aws s3 sync . s3://calligre-us-east-1/lambda/ --exclude "*" --include "*.zip" --delete
-      - aws s3 sync . s3://calligre-us-east-2/lambda/ --exclude "*" --include "*.zip" --delete
-      - aws s3 sync . s3://calligre-us-west-1/lambda/ --exclude "*" --include "*.zip" --delete
-      - aws s3 sync . s3://calligre-us-west-2/lambda/ --exclude "*" --include "*.zip" --delete
-      - aws s3 sync . s3://calligre-eu-west-1/lambda/ --exclude "*" --include "*.zip" --delete
-      - aws s3 sync . s3://calligre-eu-west-2/lambda/ --exclude "*" --include "*.zip" --delete
+      - aws s3 sync . s3://calligre-us-east-1/lambda/ --exclude "*" --include "*.zip" --delete --region us-east-1
+      - aws s3 sync . s3://calligre-us-east-2/lambda/ --exclude "*" --include "*.zip" --delete --region us-east-2
+      - aws s3 sync . s3://calligre-us-west-1/lambda/ --exclude "*" --include "*.zip" --delete --region us-west-1
+      - aws s3 sync . s3://calligre-us-west-2/lambda/ --exclude "*" --include "*.zip" --delete --region us-west-2
+      - aws s3 sync . s3://calligre-eu-west-1/lambda/ --exclude "*" --include "*.zip" --delete --region eu-west-1
+      - aws s3 sync . s3://calligre-eu-west-2/lambda/ --exclude "*" --include "*.zip" --delete --region eu-west-2


### PR DESCRIPTION
The AWS CLI looks like it uses sigv2 internally, and can't handle the new regions automatically. They aren't following their own best practice of "All AWS services support Signature Version 4, [...] we recommend that you use Signature Version 4."

eg https://circleci.com/gh/Calligre/lambda-functions/54